### PR TITLE
fix for change only manage arrays

### DIFF
--- a/tasks/arrays.yml
+++ b/tasks/arrays.yml
@@ -11,12 +11,12 @@
 # Creating raid arrays
 # We pass yes in order to accept any questions prompted for yes|no
 - name: arrays | Creating Array(s)
-  shell: "yes | mdadm --create /dev/{{ item.name }} --level={{ item.level }} --chunk={{item.chunk_size|default(512K)}} --metadata={{ item.raid_metadata_version | default(1.2) }} --raid-devices={{ item.devices|count }} {{ item.devices| join (' ') }}"
+  shell: "yes | mdadm --create /dev/{{ item.1.name }} --level={{ item.1.level }} --chunk={{item.1.chunk_size|default(512K)}} --metadata={{ item.1.raid_metadata_version | default(1.2) }} --raid-devices={{ item.1.devices|count }} {{ item.1.devices| join (' ') }}"
   register: "array_created"
-  with_items: '{{ mdadm_arrays }}'
+  with_indexed_items: '{{ mdadm_arrays }}'
   when: >
-        item.state|lower == "present" and
-        array_check.results[0].rc != 0
+        item.1.state|lower == "present" and
+        array_check.results[item.0].rc != 0
 
 # Updates initramfs archives in /boot
 - name: arrays | Updating Initramfs
@@ -26,9 +26,10 @@
 # Capture the raid array details to append to mdadm.conf
 # in order to persist between reboots
 - name: arrays | Capturing Array Details
-  command: "mdadm --detail --scan"
+  command: "mdadm --detail --scan /dev/{{ item.name }}"
   register: "array_details"
   changed_when: false
+  with_items: '{{ mdadm_arrays }}'
 
 # Creating raid arrays filesystem
 - name: arrays | Creating Array(s) Filesystem
@@ -123,9 +124,9 @@
   lineinfile:
     dest: "{{ mdadm_conf }}"
     regexp: "^{{ item }}"
-    line: "{{ item }}"
+    line: "{{ items.stdout }}"
     state: "present"
-  with_items: '{{ array_details.stdout_lines }}'
+  with_items: '{{ array_details.results }}'
   when: array_created.changed
 
 # Updating mdadm.conf in order to not persist between reboots


### PR DESCRIPTION
## Description
Improving on two things:
1. when creating an array, I add a check for each array that the array has already been created
previously only the first array was checked, and the second array was not created if the first array was already created earlier, during previous playbook launches

2. improve the work on creating mdamd.conf so that playbook makes changes only for the arrays it controls. otherwise there may be problems with arrays already in the system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
